### PR TITLE
feat: Truncate featured sitter names to 12 chars

### DIFF
--- a/app/features/home/components/FeaturedSitters.tsx
+++ b/app/features/home/components/FeaturedSitters.tsx
@@ -7,6 +7,13 @@ import { useRouter } from 'expo-router';
 
 const { width } = Dimensions.get('window');
 
+const truncateName = (name: string, maxLength: number): string => {
+  if (name.length > maxLength) {
+    return name.substring(0, maxLength) + "...";
+  }
+  return name;
+};
+
 interface FeaturedSittersProps {
   onSitterPress?: (sitter: any) => void;
   animationDelay?: number;
@@ -93,7 +100,7 @@ export function FeaturedSitters({
                   />
                   
                   <View style={styles.featuredInfo}>
-                    <Text style={styles.featuredSitterName}>{item.name} </Text>
+                    <Text style={styles.featuredSitterName}>{truncateName(item.name, 12)} </Text>
                     
                     <View style={styles.ratingContainer}>
                       {item.reviews > 0 ? (


### PR DESCRIPTION
Limits the displayed name length of featured sitters in the home page to 12 characters. If a name exceeds this limit, it is truncated and "..." is appended.

This prevents names from overlapping with the "Trusted +" badge.