### PR TITLE
Fix: Truncate sitter name in profile screen

### DIFF
--- a/app/sitter/[id].tsx
+++ b/app/sitter/[id].tsx
@@ -51,6 +51,14 @@ export default function SitterProfileScreen() {
   const [selectedRating, setSelectedRating] = useState(0);
   const [submittingReview, setSubmittingReview] = useState(false);
   const { user } = useAuthStore();
+
+  // Helper function to truncate name
+  const truncateName = (name: string, maxLength: number, ellipsis: string) => {
+    if (name.length > maxLength) {
+      return name.substring(0, maxLength) + ellipsis;
+    }
+    return name;
+  };
   
   useEffect(() => {
     const fetchSitterData = async () => {
@@ -189,7 +197,9 @@ export default function SitterProfileScreen() {
           />
           <View style={styles.profileInfo}>
             <View style={styles.nameRow}>
-              <Text style={styles.name}>{sitter?.name || 'Loading...'}</Text>
+              <Text style={styles.name}>
+                {sitter?.name ? truncateName(sitter.name, 12, "...") : 'Loading...'}
+              </Text>
               <View style={styles.verifiedBadge}>
                 <Shield size={14} color="#0288D1" />
                 <Text style={styles.verifiedText}>Verified</Text>


### PR DESCRIPTION
This commit introduces a helper function to truncate the sitter's name to a maximum of 12 characters followed by an ellipsis (...) on the sitter profile screen.

The changes were made in `app/sitter/[id].tsx`. The `truncateName` function was added and is used to process `sitter.name` before display. This ensures that long names do not break the layout of the sitter card. The loading state ('Loading...') is preserved.